### PR TITLE
Fix incorrect openURL method called

### DIFF
--- a/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
+++ b/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
@@ -41,8 +41,7 @@
     } else {
         return [self identity_application:application
                                   openURL:url
-                        sourceApplication:sourceApplication
-                               annotation:annotation];
+                                  options:options];
     }
 }
 


### PR DESCRIPTION
Incorrect method was called causing loops and potentially preventing other cordova plugins to handle openURL.

Special thanks to @charlieMonroe for helping me on this.