### PR TITLE
Fix continueUserActivity method Swizzling

### DIFF
--- a/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
+++ b/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
@@ -5,11 +5,33 @@
 
 @implementation AppDelegate (FirebaseDynamicLinksPlugin)
 
+// Borrowed from http://nshipster.com/method-swizzling/
 + (void)load {
-    method_exchangeImplementations(
-        class_getInstanceMethod(self, @selector(application:continueUserActivity:restorationHandler:)),
-        class_getInstanceMethod(self, @selector(identity_application:continueUserActivity:restorationHandler:))
-    );
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(application:continueUserActivity:restorationHandler:);
+        SEL swizzledSelector = @selector(identity_application:continueUserActivity:restorationHandler:);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        BOOL didAddMethod =
+        class_addMethod(class,
+                        originalSelector,
+                        method_getImplementation(swizzledMethod),
+                        method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
 }
 
 // [START continueuseractivity]


### PR DESCRIPTION
The previous implementation did not account for the original `application:continueUserActivity:restorationHandler:` to be nil. When that happens the methods are not exchanged.