### PR TITLE
Fallback for handleUniversalLink returning nil

### DIFF
--- a/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
+++ b/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
@@ -21,6 +21,12 @@
     BOOL handled = [[FIRDynamicLinks dynamicLinks]
         handleUniversalLink:userActivity.webpageURL
         completion:^(FIRDynamicLink * _Nullable dynamicLink, NSError * _Nullable error) {
+            // Try this method as some dynamic links are not recognize by handleUniversalLink
+            // ISSUE: https://github.com/firebase/firebase-ios-sdk/issues/743
+            dynamicLink = dynamicLink ? dynamicLink
+                : [[FIRDynamicLinks dynamicLinks]
+                   dynamicLinkFromUniversalLinkURL:userActivity.webpageURL];
+            
             if (dynamicLink) {
                 [dl postDynamicLink:dynamicLink];
             }


### PR DESCRIPTION
Sometimes `handleUniversalLink` incorrectly returns nil.
https://github.com/firebase/firebase-ios-sdk/issues/743