### PR TITLE
Cordova variable support to override default Android Gradle & iOS Cocoapods dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,65 @@
 
     $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable APP_DOMAIN="example.com" --variable PAGE_LINK_DOMAIN="example.page.link"
 
-Use variable `APP_DOMAIN` specify web URL where your app will start an activity to handle the link.
+### Required Variables
 
-Use variable `PAGE_LINK_DOMAIN` specify your `*.page.link` domain.
+1. Use variable `APP_DOMAIN` specify web URL where your app will start an activity to handle the link.
+2. Use variable `PAGE_LINK_DOMAIN` specify your `*.page.link` domain.
 
-Use variable `FIREBASE_DYNAMIC_LINKS_VERSION` and `FIREBASE_CORE_VERSION` to override dependency version on Android.
+### Optional Variables (to specify dependent library versions)
+
+This plugin depends on various external dependencies such as Firebase SDK & other Cordova plugins which are downloaded & integrated by 
+Gradle on Android and Cocoapods on iOS. By default this plugin uses some specific versions of these external dependencies. If you want to
+ see the default versions on these dependencies, see all the `preference` available in `plugin.xml` for `<platform name="ios">` &
+`<platform name="android">`. For example:
+
+```xml
+<preference name="IOS_FIREBASE_CORE_VERSION" default="~> 6.3.0"/>
+```
+
+When you use some another Cordova plugin which uses the similar dependency as of this plugin, there will be a big chance that the 
+version in other plugin doesn't match with the version in this plugin. This will result in build failure when you use both the plugins.
+ 
+For example: This plugin uses iOS `Firebase/Core` **v6.3.0** while the [codova-plugin-fireabse-lib](https://github.com/wizpanda/cordova-plugin-firebase-lib)
+plugin uses **v5.20.2**. When you use both the plugins, you build will definitely fail as there is major difference in the dependency. To 
+fix this issue, you can override these default values at the time of plugin installation as command-line arguments:
+
+```bash
+cordova plugin add cordova-plugin-firebase-dynamiclinks --variable IOS_FIREBASE_CORE_VERSION="5.20.2"
+```
+
+Or you can specify them in `package.json` (Cordova CLI 9):
+
+```json
+{
+    "cordova": {
+        "plugins": {
+            "cordova-plugin-firebase-dynamiclinks": {
+                "APP_DOMAIN": "example.com",
+                "PAGE_LINK_DOMAIN": "example.page.link",
+                "IOS_FIREBASE_CORE_VERSION": "5.20.2"
+            }
+        }
+    }
+}
+```
+
+Following are all the plugin variables which can be used to specify external dependencies:
+
+**Android Gradle dependencies:**
+
+- `ANDROID_FIREBASE_CORE_VERSION` for `com.google.firebase:firebase-core`
+- `ANDROID_FIREBASE_DYNAMIC_LINKS_VERSION` for `com.google.firebase:firebase-dynamic-links`
+
+**Android Cordova plugin dependencies:**
+
+- `ANDROID_SUPPORT_CORDOVA_PLUGIN_VERSION` for `cordova-support-android-plugin`
+- `ANDROID_SUPPORT_GOOGLE_SERVICES_VERSION` for `cordova-support-google-services`
+
+**iOS Cocoapods dependencies:**
+
+- `IOS_FIREBASE_CORE_VERSION` for `Firebase/Core`
+- `IOS_FIREBASE_DYNAMIC_LINKS_VERSION` for `Firebase/DynamicLinks`
 
 ## Quirks
 On Android you have to add `AndroidLaunchMode` setting in order to prevent creating of multiple app activities:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@
 <!-- MarkdownTOC levels="2" autolink="true" -->
 
 - [Supported Platforms](#supported-platforms)
+- [Supported Cordova Platforms](#supported-cordova-platforms)
 - [Installation](#installation)
+  - [Required Variables](#required-variables)
+  - [Optional Variables (to specify dependent library versions)](#optional-variables-to-specify-dependent-library-versions)
 - [Quirks](#quirks)
 - [Methods](#methods)
+  - [onDynamicLink(_callback_)](#ondynamiclink_callback_)
+  - [createDynamicLink(_parameters_)](#createdynamiclink_parameters_)
+  - [createShortDynamicLink(_parameters_)](#createshortdynamiclink_parameters_)
+  - [createUnguessableDynamicLink(_parameters_)](#createunguessabledynamiclink_parameters_)
 - [Dynamic link parameters](#dynamic-link-parameters)
 
 <!-- /MarkdownTOC -->
@@ -21,10 +28,20 @@
 
 - iOS
 - Android
+
+## Supported Cordova Platforms
+
+- `cordava-cli >= 9.0.0` (Hence `cordova-lib >= 9.0.0`)
+- `cordava-android >= 8.0.0`
+- `cordava-ios >= 5.0.0`
  
 ## Installation
 
-    $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable APP_DOMAIN="example.com" --variable PAGE_LINK_DOMAIN="example.page.link"
+```bash
+cordova plugin add cordova-plugin-firebase-dynamiclinks \
+    --variable APP_DOMAIN="example.com" \
+    --variable PAGE_LINK_DOMAIN="example.page.link"
+```
 
 ### Required Variables
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-xmlns:android="http://schemas.android.com/apk/res/android"
-           id="cordova-plugin-firebase-dynamiclinks"
-      version="3.0.0">
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        id="cordova-plugin-firebase-dynamiclinks"
+        version="3.0.0">
 
     <name>FirebaseDynamicLinksPlugin</name>
     <description>Cordova plugin for Firebase Dynamic Links</description>
@@ -22,9 +22,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <preference name="PAGE_LINK_DOMAIN" />
 
     <platform name="android">
-        <preference name="FIREBASE_CORE_VERSION" default="17.0.+"/>
-        <preference name="FIREBASE_DYNAMIC_LINKS_VERSION" default="18.0.+"/>
-
         <config-file parent="/*" target="res/xml/config.xml">
             <preference name="DYNAMIC_LINK_URIPREFIX" value="https://$PAGE_LINK_DOMAIN"/>
             <feature name="FirebaseDynamicLinks">
@@ -51,11 +48,17 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <source-file src="src/android/FirebaseDynamicLinksPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase" />
 
-        <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
-        <dependency id="cordova-support-google-services" version="^1.3.0"/>
+        <!-- Default versions for Android dependencies -->
+        <preference name="ANDROID_SUPPORT_CORDOVA_PLUGIN_VERSION" default="~1.0.0"/>
+        <preference name="ANDROID_SUPPORT_GOOGLE_SERVICES_VERSION" default="^1.3.0"/>
+        <preference name="ANDROID_FIREBASE_CORE_VERSION" default="17.0.+"/>
+        <preference name="ANDROID_FIREBASE_DYNAMIC_LINKS_VERSION" default="18.0.+"/>
 
-        <framework src="com.google.firebase:firebase-core:$FIREBASE_CORE_VERSION" />
-        <framework src="com.google.firebase:firebase-dynamic-links:$FIREBASE_DYNAMIC_LINKS_VERSION" />
+        <dependency id="cordova-support-android-plugin" version="$ANDROID_SUPPORT_CORDOVA_PLUGIN_VERSION"/>
+        <dependency id="cordova-support-google-services" version="$ANDROID_SUPPORT_GOOGLE_SERVICES_VERSION"/>
+
+        <framework src="com.google.firebase:firebase-core:$ANDROID_FIREBASE_CORE_VERSION"/>
+        <framework src="com.google.firebase:firebase-dynamic-links:$ANDROID_FIREBASE_DYNAMIC_LINKS_VERSION"/>
     </platform>
 
     <platform name="ios">
@@ -100,13 +103,17 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseDynamicLinksPlugin.h" />
         <source-file src="src/ios/FirebaseDynamicLinksPlugin.m" />
 
+        <!-- Default versions for iOS dependencies -->
+        <preference name="IOS_FIREBASE_CORE_VERSION" default="~> 6.3.0"/>
+        <preference name="IOS_FIREBASE_DYNAMIC_LINKS_VERSION" default="~> 6.3.0"/>
+
         <podspec>
             <config>
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods>
-                <pod name="Firebase/Core" spec="~> 6.3.0" />
-                <pod name="Firebase/DynamicLinks" spec="~> 6.3.0" />
+                <pod name="Firebase/Core" spec="$IOS_FIREBASE_CORE_VERSION"/>
+                <pod name="Firebase/DynamicLinks" spec="$IOS_FIREBASE_DYNAMIC_LINKS_VERSION"/>
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
# Breaking Changes

1. Renamed variable `FIREBASE_CORE_VERSION` to `ANDROID_FIREBASE_CORE_VERSION`
2. Renamed variable `FIREBASE_DYNAMIC_LINKS_VERSION` to `ANDROID_ FIREBASE_DYNAMIC_LINKS_VERSION`