### PR TITLE
Executing JavaScript callback on every scenario

### DIFF
--- a/www/FirebaseDynamicLinks.js
+++ b/www/FirebaseDynamicLinks.js
@@ -2,8 +2,8 @@ var exec = require("cordova/exec");
 var PLUGIN_NAME = "FirebaseDynamicLinks";
 
 module.exports = {
-    onDynamicLink: function(onSuccess, onError) {
-        exec(onSuccess, onError, PLUGIN_NAME, "onDynamicLink", []);
+    onDynamicLink: function(onSuccess, onError, alwaysGiveCallback) {
+        exec(onSuccess, onError, PLUGIN_NAME, "onDynamicLink", [{alwaysGiveCallback: alwaysGiveCallback}]);
     },
     createDynamicLink: function(params) {
         return new Promise(function(resolve, reject) {


### PR DESCRIPTION
## Problem

As described in the issue https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks/issues/54#issuecomment-562826134

Hi @chemerisuk 

This is an improvement to the plugin to execute the callback on every scenario. This is related to #54

```javascript
cordova.plugins.firebase.dynamiclinks.onDynamicLink(function(data) {
    console.log("App launched:", data);
});
```

## Current Behaviour

Currently, the following thing happens:

Scenario | Above callback executes
----|-----
The app is launched directly from the app icon | No
The app is launched from `APP_DOMAIN` URL | No
The app is launched from deep link URL `PAGE_LINK_DOMAIN` | Yes

## New Behaviour

Now, after we do this change, the following will happen:

Scenario | Above callback executes | Callback example
----|---|---
The app is launched directly from the app icon | Yes | ![image](https://user-images.githubusercontent.com/1804514/70562493-8227da80-1bb2-11ea-9f7d-86da12d2cab3.png)
The app is launched from `APP_DOMAIN` URL | Yes | ![image](https://user-images.githubusercontent.com/1804514/70562586-b1d6e280-1bb2-11ea-85c4-5e3e52e9bcff.png)
The app is launched from deep link URL `PAGE_LINK_DOMAIN` | Yes | ![image](https://user-images.githubusercontent.com/1804514/70562817-2742b300-1bb3-11ea-98fe-408d9ee01f72.png)

## Breaking Change

For existing developers of this plugin, if an app is not launched from the deep link URL, their callback will still be invoked.

## Workaround/Solution

Existing developers can add a simple check in their code like:

```javascript
cordova.plugins.firebase.dynamiclinks.onDynamicLink(function(data) {
    if (data.hasDeepLink) {
        // there existing code
    }
});
```

## Pending

Similar changes for iOS.

## Benefits of this change

1. Cordova developers don't have to be dependent on other plugins to figure out a way that how an app is launched.
2. Since the callback will be executed on every app launch scenario, the developer doesn't have to put any kind of wait/sleep timings just to see how the app was launched.
3. Existing developers using this plugin even don't have to change anything major in their code except one simple `if` condition.