### PR TITLE
remove useless dep and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Use variable `PAGE_LINK_DOMAIN` specify your `*.page.link` domain.
 
 Use variable `FIREBASE_DYNAMIC_LINKS_VERSION` to override dependency version on Android.
 
+On Android, to make it works on Play Store builds, you should enable Google services if not already enabled:
+```xml
+<preference name="GradlePluginGoogleServicesEnabled" value="true" />
+```
+
 ## Quirks
 On Android you have to add `AndroidLaunchMode` setting in order to prevent creating of multiple app activities:
 ```xml

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/FirebaseDynamicLinksPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase" />
 
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
-        <dependency id="cordova-support-google-services" version="^1.3.0"/>
 
         <framework src="com.google.firebase:firebase-dynamic-links:$FIREBASE_DYNAMIC_LINKS_VERSION" />
     </platform>


### PR DESCRIPTION
Hi,

Starting from cordova android 9, the implementation differ and `cordova-support-google-services` is not needed anymore, but we need to add a line in config.xml