### PR TITLE
Import OnFailureListener for respondWithDynamicLink listener

### DIFF
--- a/src/android/FirebaseDynamicLinksPlugin.java
+++ b/src/android/FirebaseDynamicLinksPlugin.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.dynamiclinks.DynamicLink;
 import com.google.firebase.dynamiclinks.DynamicLink.AndroidParameters;


### PR DESCRIPTION
This should fix a compiling issue caused with the recent https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks/commit/d6b5246390baed870b1a972b98836ba126835c40 commit for issue #54.