### PR TITLE
Added PAGE_LINK_PATHPREFIX preference for specifying Android pathPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Use variable `APP_DOMAIN_NAME` to specify your Google generated `*.page.link` domain or other custom domain.
 
-    $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable APP_DOMAIN_NAME="mydomain.com" APP_DOMAIN_PATH="/app1"
+    $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable APP_DOMAIN_NAME="mydomain.com" --variable APP_DOMAIN_PATH="/app1"
 
 Use variables `APP_DOMAIN_PATH` to speciy a specific domain path prefix when using a custom domain. This is useful if multiple apps share the same root level domain. If specified this path **must** begin with a `/`.
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@
  
 ## Installation
 
-    $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable PAGE_LINK_DOMAIN="mydomain.page.link"
+    $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable APP_DOMAIN_NAME="mydomain.page.link"
 
-Use variable `PAGE_LINK_DOMAIN` specify your `*.page.link` domain.
+Use variable `APP_DOMAIN_NAME` to specify your Google generated `*.page.link` domain or other custom domain.
+
+    $ cordova plugin add cordova-plugin-firebase-dynamiclinks --variable APP_DOMAIN_NAME="mydomain.com" APP_DOMAIN_PATH="/app1"
+
+Use variables `APP_DOMAIN_PATH` to speciy a specific domain path prefix when using a custom domain. This is useful if multiple apps share the same root level domain. If specified this path **must** begin with a `/`.
 
 Use variables `IOS_FIREBASE_DYNAMICLINKS_VERSION` and `ANDROID_FIREBASE_DYNAMICLINKS_VERSION` to override dependency versions for Firebase SDKs.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,6 +19,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </js-module>
 
     <preference name="PAGE_LINK_DOMAIN" />
+    <preference name="PAGE_LINK_PATHPREFIX" default="" />
 
     <dependency id="cordova-plugin-firebase-analytics" version="~4.5.0"/>
 
@@ -37,8 +38,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:host="$PAGE_LINK_DOMAIN" android:scheme="http"/>
-                <data android:host="$PAGE_LINK_DOMAIN" android:scheme="https"/>
+                <data android:host="$PAGE_LINK_DOMAIN" android:pathPrefix="/$PAGE_LINK_PATHPREFIX" android:scheme="http"/>
+                <data android:host="$PAGE_LINK_DOMAIN" android:pathPrefix="/$PAGE_LINK_PATHPREFIX" android:scheme="https"/>
             </intent-filter>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,8 +18,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <merges target="cordova.plugins.firebase.dynamiclinks" />
     </js-module>
 
-    <preference name="PAGE_LINK_DOMAIN" />
-    <preference name="PAGE_LINK_PATHPREFIX" default="" />
+    <preference name="APP_DOMAIN_NAME" />
+    <preference name="APP_DOMAIN_PATH" default="/" />
 
     <dependency id="cordova-plugin-firebase-analytics" version="~4.5.0"/>
 
@@ -27,7 +27,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="19.1.+"/>
 
         <config-file parent="/*" target="res/xml/config.xml">
-            <preference name="DOMAIN_URI_PREFIX" value="https://$PAGE_LINK_DOMAIN"/>
+            <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME"/>
             <feature name="FirebaseDynamicLinks">
                 <param name="android-package" value="by.chemerisuk.cordova.firebase.FirebaseDynamicLinksPlugin" />
             </feature>
@@ -38,8 +38,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:host="$PAGE_LINK_DOMAIN" android:pathPrefix="/$PAGE_LINK_PATHPREFIX" android:scheme="http"/>
-                <data android:host="$PAGE_LINK_DOMAIN" android:pathPrefix="/$PAGE_LINK_PATHPREFIX" android:scheme="https"/>
+                <data android:host="$APP_DOMAIN_NAME" android:pathPrefix="$APP_DOMAIN_PATH" android:scheme="http"/>
+                <data android:host="$APP_DOMAIN_NAME" android:pathPrefix="$APP_DOMAIN_PATH" android:scheme="https"/>
             </intent-filter>
         </config-file>
 
@@ -55,7 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="~> 6.32.2"/>
 
         <config-file parent="/*" target="config.xml">
-            <preference name="DOMAIN_URI_PREFIX" value="https://$PAGE_LINK_DOMAIN"/>
+            <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME"/>
             <feature name="FirebaseDynamicLinks">
                 <param name="ios-package" value="FirebaseDynamicLinksPlugin" />
             </feature>
@@ -78,20 +78,20 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <config-file target="*-Info.plist" parent="FirebaseDynamicLinksCustomDomains">
             <array>
-                <string>http://$PAGE_LINK_DOMAIN/PAGE_LINK_PATHPREFIX</string>
-                <string>https://$PAGE_LINK_DOMAIN/PAGE_LINK_PATHPREFIX</string>
+                <string>http://$APP_DOMAIN_NAME$APP_DOMAIN_PATH</string>
+                <string>https://$APP_DOMAIN_NAME$APP_DOMAIN_PATH</string>
             </array>
         </config-file>
 
         <config-file target="*-Debug.plist" parent="com.apple.developer.associated-domains">
             <array>
-                <string>applinks:$PAGE_LINK_DOMAIN</string>
+                <string>applinks:$APP_DOMAIN_NAME</string>
             </array>
         </config-file>
 
         <config-file target="*-Release.plist" parent="com.apple.developer.associated-domains">
             <array>
-                <string>applinks:$PAGE_LINK_DOMAIN</string>
+                <string>applinks:$APP_DOMAIN_NAME</string>
             </array>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -76,6 +76,13 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </array>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="FirebaseDynamicLinksCustomDomains">
+            <array>
+                <string>http://$PAGE_LINK_DOMAIN/PAGE_LINK_PATHPREFIX</string>
+                <string>https://$PAGE_LINK_DOMAIN/PAGE_LINK_PATHPREFIX</string>
+            </array>
+        </config-file>
+
         <config-file target="*-Debug.plist" parent="com.apple.developer.associated-domains">
             <array>
                 <string>applinks:$PAGE_LINK_DOMAIN</string>

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="19.1.+"/>
 
         <config-file parent="/*" target="res/xml/config.xml">
-            <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME"/>
+            <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME$APP_DOMAIN_PATH"/>
             <feature name="FirebaseDynamicLinks">
                 <param name="android-package" value="by.chemerisuk.cordova.firebase.FirebaseDynamicLinksPlugin" />
             </feature>
@@ -55,7 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="~> 6.32.2"/>
 
         <config-file parent="/*" target="config.xml">
-            <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME"/>
+            <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME$APP_DOMAIN_PATH"/>
             <feature name="FirebaseDynamicLinks">
                 <param name="ios-package" value="FirebaseDynamicLinksPlugin" />
             </feature>


### PR DESCRIPTION
We have multiple apps using the same domain and need to be able to specify the `pathPrefix` so that the correct app is opened. This is shown in the Android docs here: https://developer.android.com/training/app-links/deep-linking

Variables when adding the plugin look something like this:
```
--variable PAGE_LINK_DOMAIN="app.example.com" --variable PAGE_LINK_PATHPREFIX="link/app1"
--variable PAGE_LINK_DOMAIN="app.example.com" --variable PAGE_LINK_PATHPREFIX="link/app2"
```

The default for the `PAGE_LINK_PATHPREFIX` preference is set to `""` which means `android:pathPrefix="/"` should still be good for those not using it.

_This isn't an issue for iOS as app paths are set in the `apple-app-site-association` file which is hosted on the server._