### PR TITLE
Added back podspec config url

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -94,7 +94,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git" />
+                <source url="https://cdn.cocoapods.org/" />
             </config>
             <pods>
                 <pod name="Firebase/DynamicLinks" spec="$IOS_FIREBASE_DYNAMICLINKS_VERSION" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -93,6 +93,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/FirebaseDynamicLinksPlugin.m" />
 
         <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git" />
+            </config>
             <pods>
                 <pod name="Firebase/DynamicLinks" spec="$IOS_FIREBASE_DYNAMICLINKS_VERSION" />
             </pods>


### PR DESCRIPTION
I think the podspec still might be required. I noticed this when trying to add the plugin to test #54. When I run:

```
cordova plugin add https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks --variable PAGE_LINK_DOMAIN="app.example.com"
```

It throws the following error and iOS will not build:

```
Failed to install 'cordova-plugin-firebase-dynamiclinks': TypeError: Cannot convert undefined or null to object
```

They could be out of date, but the Cordova docs (https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#podspec-ios) seem to imply that the source URL is still required.

When I revert 3694e3a953268360403a42cb295ef06e26ede431 adding back in the podspec in the format listed in the docs it all works again.

```
<config>
  <source url="https://github.com/CocoaPods/Specs.git" />
</config>
```

I also don't know if it makes a difference or not but the docs seem to reference `https://github.com/CocoaPods/Specs.git` specifically over `https://cdn.cocoapods.org`. Maybe it's just something funky on my computer but I'm running Cordova 10 and Cocoapod 1.9.3.