### PR TITLE
Fix first-launch-after-install issue where valid deeplink gets clobbered by empty deeplink

### DIFF
--- a/src/ios/FirebaseDynamicLinksPlugin.m
+++ b/src/ios/FirebaseDynamicLinksPlugin.m
@@ -174,6 +174,14 @@
     [data setObject:(minimumAppVersion ? minimumAppVersion : @"") forKey:@"minimumAppVersion"];
     [data setObject:(weakConfidence ? @"Weak" : @"Strong") forKey:@"matchType"];
 
+    // Hathway code change made to avoid a "phantom" empty deeplink from clobbering a valid deeplink on first launch after install.
+    // The incoming phantom deeplink seems to be associated with a JS script being run to detect the device locale, but
+    //  there doesn't seem to be a way to prevent that from running
+    // First identified in ticket PRG-1613
+    if ([[data objectForKey:@"deepLink"] isEqualToString:@""]) {
+        return;
+    }
+
     if (self.dynamicLinkCallbackId) {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:data];
         [pluginResult setKeepCallbackAsBool:YES];


### PR DESCRIPTION
See https://github.com/firebase/firebase-ios-sdk/issues/7406#issuecomment-847184699 for a full outline of what this PR attempts to work around. But the premise is that if an incoming deeplink doesn't have any sort of meaningful URL being provided, there's not really anything the application can do to process it (except for maybe providing an error to the user?).

In our case, it just made sense to not fully process an empty deeplink URL so it doesn't get saved to `lastDynamicLinkData` which risks clobbering a "real" deeplink the user clicked to open the app for the first time.

Not at all saying this is the right approach, and there might be functionality impacts I'm not aware of, but wanted to provide this to anyone else that's experiencing the same issue we did, which seems to be documented in the following issues:
* https://github.com/chemerisuk/cordova-plugin-firebase-dynamiclinks/issues/65
* https://github.com/firebase/firebase-ios-sdk/issues/7406 (core plugin issue, see my comment https://github.com/firebase/firebase-ios-sdk/issues/7406#issuecomment-847184699 with my notes found from unwinding the logic stack)
