### PR TITLE
Use application:openURL to handle ios cold start

### DIFF
--- a/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
+++ b/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
@@ -13,6 +13,29 @@
     });
 }
 
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<NSString *, id> *)options {
+  return [self application:app
+                   openURL:url
+         sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+                annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+}
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication
+         annotation:(id)annotation {
+  FIRDynamicLink *dynamicLink = [[FIRDynamicLinks dynamicLinks] dynamicLinkFromCustomSchemeURL:url];
+
+  if (dynamicLink) {
+      FirebaseDynamicLinksPlugin* dl = [self.viewController getCommandInstance:@"FirebaseDynamicLinks"];
+      [dl postDynamicLink:dynamicLink];
+    return YES;
+  }
+  return NO;
+}
+
 + (void)swizzleMethod:(SEL)originalSelector {
     Class class = [self class];
     NSString *selectorString = NSStringFromSelector(originalSelector);


### PR DESCRIPTION
Following https://firebase.google.com/docs/dynamic-links/ios/receive#objective-c_3 (step 7), there is some code missing in order to make iOS work when the app is no installed. I'm not an iOS expert, so feel free to comment and make any suggestions/improvements.

It might be related to isues #84 #66 #50 and #15 , just in case it helps somebody.

Thanks